### PR TITLE
Update vendored DuckDB sources to 7fd3b94a1c

### DIFF
--- a/src/duckdb/src/function/table/version/pragma_version.cpp
+++ b/src/duckdb/src/function/table/version/pragma_version.cpp
@@ -1,5 +1,5 @@
 #ifndef DUCKDB_PATCH_VERSION
-#define DUCKDB_PATCH_VERSION "0-dev1925"
+#define DUCKDB_PATCH_VERSION "0-dev1927"
 #endif
 #ifndef DUCKDB_MINOR_VERSION
 #define DUCKDB_MINOR_VERSION 3
@@ -8,10 +8,10 @@
 #define DUCKDB_MAJOR_VERSION 1
 #endif
 #ifndef DUCKDB_VERSION
-#define DUCKDB_VERSION "v1.3.0-dev1925"
+#define DUCKDB_VERSION "v1.3.0-dev1927"
 #endif
 #ifndef DUCKDB_SOURCE_ID
-#define DUCKDB_SOURCE_ID "edeb947e2a"
+#define DUCKDB_SOURCE_ID "7fd3b94a1c"
 #endif
 #include "duckdb/function/table/system_functions.hpp"
 #include "duckdb/main/database.hpp"


### PR DESCRIPTION
Changes:
 - 2025-03-27 21:39:05: [duckdb/duckdb#7fd3b94a1c](https://github.com/duckdb/duckdb/commit/7fd3b94a1c)
